### PR TITLE
version

### DIFF
--- a/custom_components/morph_numbers/manifest.json
+++ b/custom_components/morph_numbers/manifest.json
@@ -2,6 +2,7 @@
   "domain": "morph_numbers",
   "name": "Morph Numbers",
   "documentation": "https://github.com/AlexxIT/MorphNumbers",
+  "version": "0.0.2",
   "dependencies": [],
   "codeowners": [
     "@AlexxIT"


### PR DESCRIPTION
No 'version' key in the manifest file for custom integration 'morph_numbers'. As of Home Assistant 2021.6, this integration will no longer be loaded. Please report this to the maintainer of 'morph_numbers'