### PR TITLE
python3.11 support

### DIFF
--- a/custom_components/morph_numbers/manifest.json
+++ b/custom_components/morph_numbers/manifest.json
@@ -6,7 +6,7 @@
   "issue_tracker": "https://github.com/AlexxIT/MorphNumbers/issues",
   "codeowners": ["@AlexxIT"],
   "dependencies": [],
-  "requirements": ["pymorphy2"],
-  "version": "1.3.0",
+  "requirements": ["pymorphy3"],
+  "version": "1.3.1",
   "iot_class": "calculated"
 }

--- a/custom_components/morph_numbers/utils.py
+++ b/custom_components/morph_numbers/utils.py
@@ -1,5 +1,5 @@
-from pymorphy2 import MorphAnalyzer
-from pymorphy2.analyzer import Parse
+from pymorphy3 import MorphAnalyzer
+from pymorphy3.analyzer import Parse
 
 NUMBERS = """0,ноль,нулевой
 1,один,первый


### PR DESCRIPTION
Use `pymorphy3` instead of `pymorphy2` which seems dead
`pymorphy2` uses `inspect.getargspec` which is deprecated since 2008
`python 3.11` does not have this method anymore